### PR TITLE
dots are more blocky

### DIFF
--- a/.setup/vaex_extended/jupyter/plot.py
+++ b/.setup/vaex_extended/jupyter/plot.py
@@ -120,7 +120,7 @@ class Plot2dDefault(Plot2dDefault):
                         val = fgrid[0][row][col]
                         if val != 0:
                             for i in range(row, max(-1, row-new_size), -1):
-                                for j in range(col, min(cols-1,col+new_size)):
+                                for j in range(col, min(cols,col+new_size)):
                                     if fgrid[0][i][j] == 0:
                                         n_fgrid[0][i][j] = val
                 fgrid = n_fgrid


### PR DESCRIPTION
## Description:

Two versions of making the space between dots smaller with one a more basic, centered version of the other

The second takes every pixel and makes it the bottom left corner of a bigger dot/box

## Risk Assessment

No known risks or bugs

## Performance Impact

May be slightly slower. Can everyone else check?

## Testing Assessment

Visual zooming in the sorting plot from dimensions of 128x128 to 32x32 and then down to 1x1
