### PR TITLE
script to compile pin

### DIFF
--- a/.setup/compile_pin.py
+++ b/.setup/compile_pin.py
@@ -20,6 +20,7 @@ parser = argparse.ArgumentParser(description="Input and Output for compiling pin
 parser.add_argument('input', nargs='?', default=TRACE_TOOL)
 parser.add_argument('output_dir', nargs='?', default=OUTPUT_PATH)
 args = parser.parse_args()
+curr_dir = os.getcwd()
 input_path = args.input
 output_path = args.output_dir
 
@@ -34,6 +35,8 @@ if output_path[-1] != "/":
     output_path+="/"
 
 full_output_path = os.path.expanduser(output_path)
+if full_output_path[0] != "/":
+    full_output_path = curr_dir + "/" + full_output_path
 print("Using - " + full_output_path)
 
 try:


### PR DESCRIPTION
## Description:

Script to compile pintool specifying path to pintool and directory to output compiled file.


## Risk Assessment

No known risks or bugs

## Performance Impact

Should speed up compiling the pintool. Could be added to other scripts.

## Testing Assessment

Tested with `trace_tool.cpp` and various output locations including `.setup/`
Error checking: Tested with missing files and directories
Lot more error checking/testing can be done, but works for its specific purpose