### PR TITLE
Feature dropdowns for Tag stats

### DIFF
--- a/moneta/moneta/legend/tags.py
+++ b/moneta/moneta/legend/tags.py
@@ -48,11 +48,11 @@ class Tags():
               'children': [{'id': i+2, 'name': stat} for i, stat in enumerate(statss)],
             }]
             treeview = v.Treeview(items=items, dense=True)
-            tag_rows.append(v.Container(row=False, class_="d-flex justify-start align-start ma-0 pa-0",children=[
+            tag_rows.append(v.Container(row=False, class_="d-flex justify-start ma-0 pa-0",children=[
                     v.Col(cols=1, children=[treeview], class_="ma-0 pa-0"),
-                    v.Col(cols=12, children=[tag_row]),
-                    treenodelabel
+                    v.Col(cols=12, children=[tag_row], class_="pt-0 pb-0")
                     ]))
+        tag_rows.append(v.Container(row=False, children=[treenodelabel]))
         return VBox([v.List(children=(all_row + tag_rows), dense=True, nav=True, max_height="300px", max_width="200px")])
 
     def create_zoom_button(self, tag): #TODO move constants out


### PR DESCRIPTION
## Description:
Added a treeview to each item which shows the stats when opened
Increased height of Tags content from 240px to 300px to accommodate one full set of stats info

## Risk Assessment

No known risks or bugs
Changed CSS of treeview. Could affect future treeviews if used

## Performance Impact

No known or significant performance impact.
Could be slower - larger legend
Can't open/close all of them at once yet

## Testing Assessment

Visual
