### PR TITLE
Return Code Instead of stderr

### DIFF
--- a/moneta/moneta/utils.py
+++ b/moneta/moneta/utils.py
@@ -242,7 +242,7 @@ def run_pintool(w_vals):
   
     os.chdir(MONETA_TOOL_DIR)
   
-    if sub_stderr:
+    if sub_output.returncode:
         print(f"{TextStyle.RED}An error occurred while running your program. "
               f"This is normally caused by Tag typos and/or stopping invalid Tags. "
               f"Double check your program and Pin tags to make sure they are correct.\n\n"


### PR DESCRIPTION
## Description:

Using return code instead of std_err/cerr to check for errors when running Pin/executable


## Risk Assessment

No known risks or bugs

## Performance Impact

No known or significant performance impact.

## Testing Assessment

Tested on segfaults (Prints error)
Tested on cerr with return 0 (Does not print error)
Tested on cerr with return 1 (Prints error)
