### PR TITLE
Feature multithreaded

### DIFF
--- a/moneta/moneta/legend/legend.py
+++ b/moneta/moneta/legend/legend.py
@@ -27,6 +27,7 @@ class Legend():
         self.accesses = Accesses(model, self.update_selection)
         self.stats = PlotStats(model)
         self.tags = Tags(model, self.update_selection)
+        self.threads = Threads(model, self.update_selection)
         self.add_panel(LEGEND_MEM_ACCESS_TITLE, self.accesses.widgets)
         self.add_panel(LEGEND_TAGS_TITLE, self.tags.widgets)
         self.add_panel(LEGEND_STATS_TITLE, self.stats.widgets)

--- a/moneta/moneta/legend/legend.py
+++ b/moneta/moneta/legend/legend.py
@@ -2,9 +2,10 @@ from ipywidgets import Button, Checkbox, ColorPicker, HBox, Label, Layout, VBox,
 import ipyvuetify as v
 from vaex.jupyter.utils import debounced
 from matplotlib.colors import to_hex, to_rgba, ListedColormap
-from moneta.settings import newc, COMP_W_MISS, COMP_R_MISS, WRITE_MISS, READ_MISS, WRITE_HIT, READ_HIT, LEGEND_MEM_ACCESS_TITLE, LEGEND_TAGS_TITLE,  LEGEND_STATS_TITLE, INDEX, ADDRESS
+from moneta.settings import newc, COMP_W_MISS, COMP_R_MISS, WRITE_MISS, READ_MISS, WRITE_HIT, READ_HIT, LEGEND_MEM_ACCESS_TITLE, LEGEND_TAGS_TITLE, LEGEND_THREADS_TITLE,  LEGEND_STATS_TITLE, INDEX, ADDRESS
 from moneta.legend.accesses import Accesses
 from moneta.legend.tags import Tags
+from moneta.legend.threads import Threads
 from moneta.legend.stats import PlotStats
 
 from enum import Enum
@@ -30,6 +31,7 @@ class Legend():
         self.threads = Threads(model, self.update_selection)
         self.add_panel(LEGEND_MEM_ACCESS_TITLE, self.accesses.widgets)
         self.add_panel(LEGEND_TAGS_TITLE, self.tags.widgets)
+        self.add_panel(LEGEND_THREADS_TITLE, self.threads.widgets)
         self.add_panel(LEGEND_STATS_TITLE, self.stats.widgets)
 
         def update_legend_icon(_panels, _, selected):
@@ -56,6 +58,9 @@ class Legend():
         for checkbox in self.tags.checkboxes:
             if checkbox.widget.v_model == False:
                 selections.add('((%s < %s) | (%s > %s) | (%s < %s) | (%s > %s))' % (INDEX, checkbox.start, INDEX, checkbox.stop, ADDRESS, checkbox.bottom, ADDRESS, checkbox.top))
+        for checkbox in self.threads.checkboxes:
+            if checkbox.widget.v_model == False:
+                pass #selections.add('((%s < %s) | (%s > %s) | (%s < %s) | (%s > %s))' % (INDEX, checkbox.start, INDEX, checkbox.stop, ADDRESS, checkbox.bottom, ADDRESS, checkbox.top))
         return '&'.join(selections)
 
     @debounced(0.5)

--- a/moneta/moneta/legend/tags.py
+++ b/moneta/moneta/legend/tags.py
@@ -1,7 +1,11 @@
 from ipywidgets import VBox, HBox, Layout, Button
 import ipyvuetify as v
 from moneta.utils import stats_percent
-from moneta.settings import ADDRESS
+from moneta.settings import ADDRESS, THREAD_ID
+
+import logging
+log = logging.getLogger(__name__)
+
 
 class Tags():
     def __init__(self, model, update_selection):
@@ -79,7 +83,13 @@ class Tags():
     def get_stats(self, tag):
         df = self.model.curr_trace.df
         rows = df[int(tag.access[0]):int(tag.access[1])+1]
-        return rows[rows[f'({ADDRESS} >= {tag.address[0]}) & ({ADDRESS} <= {tag.address[1]})']].count(binby=[df.Access], limits=[1,7], shape=[6])
+        if tag.is_thread:
+            q = f'({THREAD_ID} == {tag.thread_id})'
+            log.debug(f"q = {q}")
+        else:
+            q = f'({ADDRESS} >= {tag.address[0]}) & ({ADDRESS} <= {tag.address[1]})'
+
+        return rows[rows[q]].count(binby=[df.Access], limits=[1,7], shape=[6])
 
     def dropdown_str(self, tag, stats):
         total = sum(stats)
@@ -137,4 +147,5 @@ class Checkbox:
         self.stop = tag.access[1]
         self.top = tag.address[1]
         self.bottom = tag.address[0]
-
+        self.is_thread = tag.is_thread
+        self.thread_id = tag.thread_id

--- a/moneta/moneta/legend/threads.py
+++ b/moneta/moneta/legend/threads.py
@@ -18,7 +18,7 @@ class Threads():
         
         all_row = [v.Row(children=[self.all_check_tp], class_='ml-7')]
 
-        tag_rows = []
+        thread_rows = []
         treenodelabel = v.Html(tag='style', children=[(".vuetify-styles .v-treeview-node__label {"
             "margin-left: 0px;"
             "overflow: visible;"
@@ -36,16 +36,16 @@ class Threads():
             "min-height: 21px;"
             "}"
         )]) 
-        for tag in range(0,16): #self.model.curr_trace.tags:
-            chk = Checkbox(tag)
+        for thread in self.model.curr_trace.threads:
+            chk = Checkbox(thread)
             self.checkboxes.append(chk)
             chk.widget.on_event('change', self.update_all_checkbox)
-            stats = self.get_stats(tag)
-            btn, tooltip = self.create_zoom_button(tag, stats=stats)
-            statss = self.tag_tooltip(tag, stats).splitlines()
+            stats = self.get_stats(thread)
+            #btn, tooltip = self.create_zoom_button(tag, stats=stats)
+            statss = self.thread_tooltip(tag, stats).splitlines()
 
             tag_row = v.Row(children=[
-                btn,
+                #btn,
                 chk.widget
                 ], class_='ml-0')
             items = [{
@@ -61,12 +61,12 @@ class Threads():
         tag_rows.append(v.Container(row=False, children=[treenodelabel]))
         return VBox([v.List(children=(all_row + tag_rows), dense=True, nav=True, max_height="300px", max_width="200px")])
 
-    def create_zoom_button(self, tag, stats=None): #TODO move constants out
+    def create_zoom_button(self, thread, stats=None): #TODO move constants out
         if stats is None:
-            stats = self.get_stats(tag)
+            stats = self.get_stats(thread)
 
-        tooltip = self.tag_tooltip(tag, stats)
-        btn = Button(icon='search-plus', tooltip=self.tag_tooltip(tag, stats), 
+        tooltip = self.thread_tooltip(thread, stats)
+        btn = Button(icon='search-plus', tooltip=self.thread_tooltip(thread, stats), 
                 style={'button_color': 'transparent'},
                 layout=Layout(height='35px', width='35px',
                     borders='none', align_items='center'
@@ -79,15 +79,15 @@ class Threads():
 
     def get_stats(self, tag):
         df = self.model.curr_trace.df
-        rows = df[int(tag.access[0]):int(tag.access[1])+1]
-        return rows[rows[f'({ADDRESS} >= {tag.address[0]}) & ({ADDRESS} <= {tag.address[1]})']].count(binby=[df.Access], limits=[1,7], shape=[6])
+        rows = df #[int(tag.access[0]):int(tag.access[1])+1]  We could track the start and end of each threads, but we don't.
+        return rows.count(binby=[df.Access], limits=[1,7], shape=[6])
 
     def dropdown_str(self, tag, stats):
         total = sum(stats)
         m = len(str(total))
         final_str = (
-                f'Access Range: {tag.access[0]}, {tag.access[1]}\n'
-                f'Address Range: 0x{int(tag.address[0]):X}, 0x{int(tag.address[1]):X}\n'
+#                f'Access Range: {tag.access[0]}, {tag.access[1]}\n'
+#                f'Address Range: 0x{int(tag.address[0]):X}, 0x{int(tag.address[1]):X}\n'
                 f'Total: {total}\n'
                 f'{stats[0]:0{m}} ({stats_percent(stats[0],total)}), {stats[1]:0{m}} ({stats_percent(stats[1],total)}) Hits\n'
                 f'{stats[2]:0{m}} ({stats_percent(stats[2],total)}), {stats[3]:0{m}} ({stats_percent(stats[3],total)}) Caps\n'
@@ -95,11 +95,11 @@ class Threads():
         )
         return final_str
 
-    def tag_tooltip(self, tag, stats):
+    def thread_tooltip(self, thread, stats):
         total = sum(stats)
         final_tooltip = (
-                f'Access Range: {tag.access[0]}, {tag.access[1]}\n'
-                f'Address Range: 0x{int(tag.address[0]):X}, 0x{int(tag.address[1]):X}\n'
+#                f'Access Range: {tag.access[0]}, {tag.access[1]}\n'
+#                f'Address Range: 0x{int(tag.address[0]):X}, 0x{int(tag.address[1]):X}\n'
                 f'Total: {total}\n'
                 f'Read Hits: {stats[0]} ({stats_percent(stats[0],total)}) \n'
                 f'Write Hits: {stats[1]} ({stats_percent(stats[1],total)}) \n'
@@ -132,10 +132,5 @@ class Threads():
         self.update_selection()
 
 class Checkbox:
-    def __init__(self, tag):
-        self.widget = v.Checkbox(label=tag.name, v_model=True, class_='ma-0 mt-1 pa-0')
-        self.start = tag.access[0] # Could fix x-axis being 1 access here aka access[0] == access[1]
-        self.stop = tag.access[1]
-        self.top = tag.address[1]
-        self.bottom = tag.address[0]
-
+    def __init__(self, thread):
+        self.widget = v.Checkbox(label=f"Thread {thread}", v_model=True, class_='ma-0 mt-1 pa-0')

--- a/moneta/moneta/legend/threads.py
+++ b/moneta/moneta/legend/threads.py
@@ -1,0 +1,141 @@
+from ipywidgets import VBox, HBox, Layout, Button
+import ipyvuetify as v
+from moneta.utils import stats_percent
+from moneta.settings import ADDRESS
+
+class Threads():
+    def __init__(self, model, update_selection):
+        self.model = model
+        self.update_selection = update_selection
+        self.checkboxes = []
+        self.widgets = self.init_widgets()
+
+    def init_widgets(self):
+        self.all_check = v.Checkbox(v_on='tooltip.on', prepend_icon='fa-globe', label="All", v_model=True, class_='ma-0 mt-1 pa-0')
+        self.all_check_tp = v.Tooltip(bottom=True, v_slots=[{'name': 'activator', 'variable': 'tooltip', 'children': self.all_check}],
+                children=["Select all threads"])
+        self.all_check.on_event('change', self.check_all)
+        
+        all_row = [v.Row(children=[self.all_check_tp], class_='ml-7')]
+
+        tag_rows = []
+        treenodelabel = v.Html(tag='style', children=[(".vuetify-styles .v-treeview-node__label {"
+            "margin-left: 0px;"
+            "overflow: visible;"
+            "}"
+            ".vuetify-styles .v-input--selection-controls:not(.v-input--hide-details) .v-input__slot {"
+            "margin-bottom: 0px;"
+            "}"
+            ".vuetify-styles .v-treeview-node__root .v-icon.v-icon.v-icon--link {"
+            "margin-bottom: 10px;"
+            "}"
+            ".vuetify-styles .v-treeview-node--leaf {"
+            "margin-left: 0px;"
+            "}"
+            ".vuetify-styles .v-treeview--dense .v-treeview-node__root {"
+            "min-height: 21px;"
+            "}"
+        )]) 
+        for tag in range(0,16): #self.model.curr_trace.tags:
+            chk = Checkbox(tag)
+            self.checkboxes.append(chk)
+            chk.widget.on_event('change', self.update_all_checkbox)
+            stats = self.get_stats(tag)
+            btn, tooltip = self.create_zoom_button(tag, stats=stats)
+            statss = self.tag_tooltip(tag, stats).splitlines()
+
+            tag_row = v.Row(children=[
+                btn,
+                chk.widget
+                ], class_='ml-0')
+            items = [{
+              'id': 1,
+              'name': '',
+              'children': [{'id': i+2, 'name': stat} for i, stat in enumerate(statss)],
+            }]
+            treeview = v.Treeview(items=items, dense=True)
+            tag_rows.append(v.Container(row=False, class_="d-flex justify-start ma-0 pa-0",children=[
+                    v.Col(cols=1, children=[treeview], class_="ma-0 pa-0"),
+                    v.Col(cols=12, children=[tag_row], class_="pt-0 pb-0")
+                    ]))
+        tag_rows.append(v.Container(row=False, children=[treenodelabel]))
+        return VBox([v.List(children=(all_row + tag_rows), dense=True, nav=True, max_height="300px", max_width="200px")])
+
+    def create_zoom_button(self, tag, stats=None): #TODO move constants out
+        if stats is None:
+            stats = self.get_stats(tag)
+
+        tooltip = self.tag_tooltip(tag, stats)
+        btn = Button(icon='search-plus', tooltip=self.tag_tooltip(tag, stats), 
+                style={'button_color': 'transparent'},
+                layout=Layout(height='35px', width='35px',
+                    borders='none', align_items='center'
+                ))
+        def zoom_to_selection(*_):
+            self.model.plot.backend.zoom_sel(float(tag.access[0]), float(tag.access[1])+1,
+                                    float(tag.address[0]), float(tag.address[1])+1)
+        btn.on_click(zoom_to_selection)
+        return btn, tooltip
+
+    def get_stats(self, tag):
+        df = self.model.curr_trace.df
+        rows = df[int(tag.access[0]):int(tag.access[1])+1]
+        return rows[rows[f'({ADDRESS} >= {tag.address[0]}) & ({ADDRESS} <= {tag.address[1]})']].count(binby=[df.Access], limits=[1,7], shape=[6])
+
+    def dropdown_str(self, tag, stats):
+        total = sum(stats)
+        m = len(str(total))
+        final_str = (
+                f'Access Range: {tag.access[0]}, {tag.access[1]}\n'
+                f'Address Range: 0x{int(tag.address[0]):X}, 0x{int(tag.address[1]):X}\n'
+                f'Total: {total}\n'
+                f'{stats[0]:0{m}} ({stats_percent(stats[0],total)}), {stats[1]:0{m}} ({stats_percent(stats[1],total)}) Hits\n'
+                f'{stats[2]:0{m}} ({stats_percent(stats[2],total)}), {stats[3]:0{m}} ({stats_percent(stats[3],total)}) Caps\n'
+                f'{stats[4]:0{m}} ({stats_percent(stats[4],total)}), {stats[5]:0{m}} ({stats_percent(stats[5],total)}) Comp\n'
+        )
+        return final_str
+
+    def tag_tooltip(self, tag, stats):
+        total = sum(stats)
+        final_tooltip = (
+                f'Access Range: {tag.access[0]}, {tag.access[1]}\n'
+                f'Address Range: 0x{int(tag.address[0]):X}, 0x{int(tag.address[1]):X}\n'
+                f'Total: {total}\n'
+                f'Read Hits: {stats[0]} ({stats_percent(stats[0],total)}) \n'
+                f'Write Hits: {stats[1]} ({stats_percent(stats[1],total)}) \n'
+                f'Total Hits: {stats[0]+stats[1]} ({stats_percent(stats[0]+stats[1],total)}) \n'
+                f'Capacity Read Misses: {stats[2]} ({stats_percent(stats[2],total)}) \n'
+                f'Capacity Write Misses: {stats[3]} ({stats_percent(stats[3],total)}) \n'
+                f'Total Capacity Misses: {stats[2]+stats[3]} ({stats_percent(stats[2]+stats[3],total)}) \n'
+                f'Compulsory Read Misses: {stats[4]} ({stats_percent(stats[4],total)}) \n'
+                f'Compulsory Write Misses: {stats[5]} ({stats_percent(stats[5],total)}) \n'
+                f'Total Compulsory Misses: {stats[4]+stats[5]} ({stats_percent(stats[4]+stats[5],total)}) \n'
+        )
+        return final_tooltip
+
+    def check_all(self, _checkbox, _, new):
+        self.all_check.indeterminate = False
+        for checkbox in self.checkboxes:
+            checkbox.widget.v_model = new
+        self.update_selection()
+
+    def update_all_checkbox(self, *_):
+        on = 0
+        off = 0
+        for checkbox in self.checkboxes:
+            if checkbox.widget.v_model:
+                on+=1
+            else:
+                off+=1
+        self.all_check.v_model = on == len(self.checkboxes)
+        self.all_check.indeterminate = on > 0 and off > 0
+        self.update_selection()
+
+class Checkbox:
+    def __init__(self, tag):
+        self.widget = v.Checkbox(label=tag.name, v_model=True, class_='ma-0 mt-1 pa-0')
+        self.start = tag.access[0] # Could fix x-axis being 1 access here aka access[0] == access[1]
+        self.stop = tag.access[1]
+        self.top = tag.address[1]
+        self.bottom = tag.address[0]
+

--- a/moneta/moneta/main.py
+++ b/moneta/moneta/main.py
@@ -19,7 +19,7 @@ def main():
 
     logger.info("Starting main")
     view.View(model.Model())
-    pass
+
 
 if __name__ == '__main__':
     main()

--- a/moneta/moneta/model.py
+++ b/moneta/moneta/model.py
@@ -10,7 +10,7 @@ class Model():
     def __init__(self):
         log.info("__init__")
         self.output_traces = None
-        self.trace_map = None
+        self.trace_map = dict()
 
         self.curr_trace = None
         self.legend = None
@@ -32,7 +32,15 @@ class Model():
         return True
 
     def load_trace(self, trace_name):
-        trace_path, tag_path, meta_path, _ = self.trace_map[trace_name]      
+        if trace_name in self.trace_map:
+            trace_path, tag_path, meta_path, _ = self.trace_map[trace_name]
+        else:
+            trace_path = trace_name + ".hdf5"
+            tag_path = trace_name + ".tags"
+            meta_path = trace_name + ".meta"
+        log.debug(f"trace_path = {trace_path}")
+        log.debug(f"tag_path = {tag_path}")
+        log.debug(f"meta_path = {meta_path}")
         self.curr_trace = Trace(trace_name, trace_path, tag_path, meta_path)
         return self.curr_trace.err_message
 

--- a/moneta/moneta/model.py
+++ b/moneta/moneta/model.py
@@ -49,16 +49,16 @@ class Model():
     def create_plot(self):
         self.legend = Legend(self)
         self.plot = self.curr_trace.df.plot_widget(
-                    self.curr_trace.df[INDEX], self.curr_trace.df[ADDRESS], 
-                    what='max(Access)', colormap=CUSTOM_CMAP, 
-                    selection=[True], limits=[self.curr_trace.x_lim, self.curr_trace.y_lim],
-                    backend='moneta_backend', type='vaextended', model=self,
-                    x_col=INDEX, y_col=ADDRESS, x_label=INDEX_LABEL, y_label=ADDRESS_LABEL, 
-                    update_stats=self.legend.stats.update,
-                    show=False
-                 )
-
-
+            self.curr_trace.df[INDEX], self.curr_trace.df[ADDRESS], 
+            what='max(Access)', colormap=CUSTOM_CMAP, 
+            selection=[True], limits=[self.curr_trace.x_lim, self.curr_trace.y_lim],
+            backend='moneta_backend', type='vaextended', model=self,
+            x_col=INDEX, y_col=ADDRESS, x_label=INDEX_LABEL, y_label=ADDRESS_LABEL, 
+            update_stats=self.legend.stats.update,
+            show=False
+        )
+        
+        
     def delete_traces(self, traces):
         delete_traces(map(lambda x: self.trace_map[x], traces))
         

--- a/moneta/moneta/settings.py
+++ b/moneta/moneta/settings.py
@@ -138,11 +138,12 @@ HI_ADDR = "High_Address"
 F_ACC = "First_Access"
 L_ACC = "Last_Access"
 TAG_NAME = "Tag_Name"
+IS_THREAD="Is_Thread"
+TAG_FILE_THREAD_ID="Thread_ID"
 
 # Legend variables
 LEGEND_MEM_ACCESS_TITLE = 'Accesses'
 LEGEND_TAGS_TITLE = 'Tags'
-LEGEND_THREADS_TITLE = 'Threads'
 LEGEND_STATS_TITLE = 'Stats'
 
 # Legend grid box

--- a/moneta/moneta/settings.py
+++ b/moneta/moneta/settings.py
@@ -138,12 +138,13 @@ HI_ADDR = "High_Address"
 F_ACC = "First_Access"
 L_ACC = "Last_Access"
 TAG_NAME = "Tag_Name"
-IS_THREAD="Is_Thread"
+TAG_FILE_TAG_TYPE="Tag_Type"
 TAG_FILE_THREAD_ID="Thread_ID"
 
 # Legend variables
 LEGEND_MEM_ACCESS_TITLE = 'Accesses'
 LEGEND_TAGS_TITLE = 'Tags'
+LEGEND_THREADS_TITLE = 'Threads'
 LEGEND_STATS_TITLE = 'Stats'
 
 # Legend grid box

--- a/moneta/moneta/settings.py
+++ b/moneta/moneta/settings.py
@@ -142,6 +142,7 @@ TAG_NAME = "Tag_Name"
 # Legend variables
 LEGEND_MEM_ACCESS_TITLE = 'Accesses'
 LEGEND_TAGS_TITLE = 'Tags'
+LEGEND_THREADS_TITLE = 'Threads'
 LEGEND_STATS_TITLE = 'Stats'
 
 # Legend grid box

--- a/moneta/moneta/settings.py
+++ b/moneta/moneta/settings.py
@@ -118,6 +118,7 @@ INDEX = "index"
 ADDRESS = "Address"
 ACCESS = "Access"
 TAG = "Tag"
+THREAD_ID = "ThreadID"
 
 ### Axis Labels
 INDEX_LABEL = "Access Number"

--- a/moneta/moneta/trace.py
+++ b/moneta/moneta/trace.py
@@ -1,4 +1,4 @@
-from moneta.settings import NO_TAGS, INDEX, ADDRESS, LO_ADDR, HI_ADDR, F_ACC, L_ACC, TAG_NAME
+from moneta.settings import NO_TAGS, INDEX, ADDRESS, LO_ADDR, HI_ADDR, F_ACC, L_ACC, TAG_NAME, IS_THREAD, TAG_FILE_THREAD_ID
 import numpy as np
 import vaex
 import csv
@@ -11,7 +11,8 @@ class Tag():
         self.address = (tag_dict[LO_ADDR], tag_dict[HI_ADDR])
         self.access = (tag_dict[F_ACC], tag_dict[L_ACC])
         self.name = tag_dict[TAG_NAME]
-
+        self.thread_id = int(tag_dict.get(TAG_FILE_THREAD_ID, "0"))
+        self.is_thread = True if tag_dict.get(IS_THREAD, "False") == "True" else False
         
 class Trace():
     def __init__(self, name, trace_path, tag_path, meta_path):
@@ -33,25 +34,25 @@ class Trace():
 
     def retrieve_tags(self):
         self.tags = []
-        try:
-            with open(self.tag_path) as f:
-                rows = csv.DictReader(f)
-                for row in rows:
-                    self.tags.append(Tag(row))
-        except:
-            pass
-
+        with open(self.tag_path) as f:
+            rows = csv.DictReader(f)
+            for row in rows:
+                log.debug(f"found tag '{row['Tag_Name']}': {row}")
+                self.tags.append(Tag(row))
+                
     def retrieve_meta_data(self):
         with open(self.meta_path) as f:
             lines = f.readlines()
             lines_split = lines[0].split()
         self.cache_lines = int(lines_split[0])
         self.cache_block = int(lines_split[1])
-
+        log.debug(f"cache_lines = {self.cache_lines}")
+        log.debug(f"cache_block = {self.cache_block}")
         if len(lines) > 1:
             self.threads = map(int,lines[1].split())
         else:
             self.threads = [0]
+        log.debug(f"threads: {self.threads}")
             
     def init_df(self):
         self.df = vaex.open(self.trace_path)

--- a/moneta/moneta/trace.py
+++ b/moneta/moneta/trace.py
@@ -12,6 +12,7 @@ class Tag():
         self.access = (tag_dict[F_ACC], tag_dict[L_ACC])
         self.name = tag_dict[TAG_NAME]
 
+        
 class Trace():
     def __init__(self, name, trace_path, tag_path, meta_path):
         log.info("__init__")

--- a/moneta/moneta/trace.py
+++ b/moneta/moneta/trace.py
@@ -27,7 +27,7 @@ class Trace():
             self.err_message = NO_TAGS
             return
         self.init_df()
-        self.retrieve_cache_info()
+        self.retrieve_meta_data()
         self.legend_state = None
 
 
@@ -41,13 +41,18 @@ class Trace():
         except:
             pass
 
-    def retrieve_cache_info(self):
+    def retrieve_meta_data(self):
         with open(self.meta_path) as f:
             lines = f.readlines()
             lines_split = lines[0].split()
         self.cache_lines = int(lines_split[0])
         self.cache_block = int(lines_split[1])
 
+        if len(lines) > 1:
+            self.threads = map(int,lines[1].split())
+        else:
+            self.threads = [0]
+            
     def init_df(self):
         self.df = vaex.open(self.trace_path)
         num_accs = self.df[ADDRESS].count()

--- a/moneta/pin_tags.h
+++ b/moneta/pin_tags.h
@@ -8,6 +8,7 @@ extern "C" {
 	__attribute__ ((optimize("O0"))) void M_NEW_TRACE(const char* name) {}
 	__attribute__ ((optimize("O0"))) void DUMP_START_ALL(const char* tag, bool create_new) {DUMP_START(tag, 0, (void*)-1, create_new);}
 	__attribute__ ((optimize("O0"))) void DUMP_STOP(const char* tag) {}
+	__attribute__ ((optimize("O0"))) int GET_THREAD_ID() { return 0;}
 	
 	__attribute__ ((optimize("O0"))) void M_START_TRACE(bool one, bool two) {}
 	__attribute__ ((optimize("O0"))) void M_STOP_TRACE(bool one, bool two) {}

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,8 @@ setup(name='Moneta',
       package_dir={'': 'moneta'},
       entry_points={
           'console_scripts' :[
-              'mtrace=mtrace:main'
+              'mtrace=mtrace:main',
+              'mtool=mtool:main'
               ]
       }
 )

--- a/setup/trace_tool.cpp
+++ b/setup/trace_tool.cpp
@@ -1149,8 +1149,8 @@ int main(int argc, char *argv[]) {
   RTN_AddInstrumentFunction(FindStartFunc, 0);
   INS_AddInstrumentFunction(Instruction, 0);
   TRACE_AddInstrumentFunction(Trace, 0);
-  PIN_AddThreadStartFunction(ThreadStart, 0);
-  PIN_AddThreadFiniFunction(ThreadStop, 0);
+  //PIN_AddThreadStartFunction(ThreadStart, 0);
+  //PIN_AddThreadFiniFunction(ThreadStop, 0);
   
   PIN_AddFiniFunction(Fini, 0);
 

--- a/setup/trace_tool.cpp
+++ b/setup/trace_tool.cpp
@@ -281,9 +281,9 @@ class HandleHdf5 {
     hsize_t max_dims[1] = {H5S_UNLIMITED}; // For extendable dataset
     H5::DataSpace m_dataspace {1, idims_t, max_dims}; // Initial dataspace
     // Create and write datasets to file
-    acc_d = mem_file.createDataSet(AccessColumn.c_str(), H5::PredType::NATIVE_UINT8, m_dataspace, plist);
+    acc_d =      mem_file.createDataSet(AccessColumn.c_str(),   H5::PredType::NATIVE_UINT8, m_dataspace, plist);
     threadid_d = mem_file.createDataSet(ThreadIDColumn.c_str(), H5::PredType::NATIVE_UINT8, m_dataspace, plist);
-    addr_d = mem_file.createDataSet(AddressColumn.c_str(), H5::PredType::NATIVE_ULLONG, m_dataspace, plist);
+    addr_d =     mem_file.createDataSet(AddressColumn.c_str(),  H5::PredType::NATIVE_ULLONG, m_dataspace, plist);
 
     //H5::DataSpace c_dataspace {1, idims_t, max_dims};
     //cache_d = cache_file.createDataSet(CacheAccessColumn.c_str(), H5::PredType::NATIVE_ULLONG, c_dataspace, plist);
@@ -308,8 +308,8 @@ class HandleHdf5 {
     addr_d.write( addrs, H5::PredType::NATIVE_ULLONG, new_dataspace, old_dataspace);
 
     old_dataspace = threadid_d.getSpace(); // Rinse and repeat
-    old_dataspace.selectHyperslab( H5S_SELECT_SET, curr_chunk_dims, offset);
-    threadid_d.write( threadids, H5::PredType::NATIVE_ULLONG, new_dataspace, old_dataspace);
+    old_dataspace.selectHyperslab(H5S_SELECT_SET, curr_chunk_dims, offset);
+    threadid_d.write(threadids, H5::PredType::NATIVE_UINT8, new_dataspace, old_dataspace);
   }
 
   // Extends dataset and writes stored chunk
@@ -365,12 +365,12 @@ public:
   }
 
   // Write data for memory access to file
-	int write_data_mem(ADDRINT address, int access, THREADID threadid) {
+  int write_data_mem(ADDRINT address, int access, THREADID threadid) {
     if (HDF_DEBUG) {
       std::cerr << "Write to Hdf5 - memory\n";
     }
     addrs[mem_ind] = address; // Write to memory first
-    threadids[mem_ind] = threadid & 0xff;
+    threadids[mem_ind] = (unsigned char)(threadid & 0xff);
     accs[mem_ind++] = access;
     if (mem_ind < chunk_size) { // Unless we have reached chunk size
       return 0;
@@ -1211,8 +1211,7 @@ int main(int argc, char *argv[]) {
   INS_AddInstrumentFunction(Instruction, 0);
   TRACE_AddInstrumentFunction(Trace, 0);
   PIN_AddThreadStartFunction(ThreadStart, 0);
-    PIN_AddThreadFiniFunction(ThreadStop, 0);
-  
+  PIN_AddThreadFiniFunction(ThreadStop, 0);
   PIN_AddFiniFunction(Fini, 0);
 
   if (DEBUG) {

--- a/setup/trace_tool.cpp
+++ b/setup/trace_tool.cpp
@@ -108,10 +108,18 @@ class PINMutexGuard {
 	PIN_MUTEX &mutex;
 public:
 	PINMutexGuard(PIN_MUTEX &m) : mutex(m) {
-		PIN_MutexLock(&mutex);
+		PIN_LockClient(); // This is not the right way to do
+				  // this, but using our own mutex
+				  // leads to hangs with multithreaded
+				  // programs.  I'm not sure why.  THe
+				  // client lock is recursive, while
+				  // the mutex is not.  That may have
+				  // something to do with it.
+		//PIN_MutexLock(&mutex);
 	}
 	~PINMutexGuard() {
-		PIN_MutexUnlock(&mutex);
+		PIN_UnlockClient();
+		//PIN_MutexUnlock(&mutex);
 	}
 	
 };

--- a/setup/trace_tool.cpp
+++ b/setup/trace_tool.cpp
@@ -544,11 +544,11 @@ void write_tags_and_clear(bool clear_tags) {
 		  });
 
 	std::ofstream tag_file (output_tagfile_path);
-	tag_file << "Tag_Name,Is_Thread,Thread_ID,Low_Address,High_Address,First_Access,Last_Access,Access_Count\n"; // Header row
+	tag_file << "Tag_Name,Tag_Type,Thread_ID,Low_Address,High_Address,First_Access,Last_Access,Access_Count\n"; // Header row
 	for (Tag* t : tags) {
 		if (t->x_range.first != -1) {
 			tag_file << t->parent->tag_name << (t->parent->tags.size() == 1 ? "" : std::to_string(t->id)) << ","
-				 << (t->is_thread ? "True" :"False") << ","
+				 << (t->is_thread ? "thread" :"space-time") << ","
 				 << t->thread_id << ","
 				 << t->addr_range.first << ","
 				 << t->addr_range.second << ","

--- a/setup/trace_tool.cpp
+++ b/setup/trace_tool.cpp
@@ -77,6 +77,7 @@ const std::string NEW_TRACE {"M_NEW_TRACE"};
 const std::string DUMP_STOP  {"DUMP_STOP"};
 const std::string FLUSH_CACHE  {"FLUSH_CACHE"};
 const std::string M_START_TRACE  {"M_START_TRACE"};
+const std::string GET_THREAD_ID  {"GET_THREAD_ID"};
 const std::string M_STOP_TRACE  {"M_STOP_TRACE"};
 
 UINT64 SkipMemOps = 10000000000000000ull;
@@ -781,6 +782,9 @@ void dump_cache(std::ostream & out) {
 	}
 }
 
+int get_thread_id() {
+	return PIN_ThreadId();
+}
 #if (0)
 #define cache_assert(exp)				\
 	do {						\
@@ -1067,6 +1071,11 @@ VOID FindFunc(IMG img, VOID *v) {
 				IARG_FUNCARG_ENTRYPOINT_VALUE, 1,
 				IARG_END);
 		RTN_Close(rtn);
+	}
+	rtn = RTN_FindByName(img, GET_THREAD_ID.c_str());
+	if(RTN_Valid(rtn)){
+		std::cerr << "replace get_thread_id\n";
+		RTN_Replace(rtn, (AFUNPTR)get_thread_id);
 	}
 }
 


### PR DESCRIPTION
## Description:

Make the tool thread safe. 

This adds the pin thread ID to the trace file.

The threads should show up in the UI somehow.  Either in the legend with checkboxes and zoom tools, or in the list of tags.

## Risk Assessment

It might break something or I might have done it wrong.

There is one known limitation:  I fixed threadID size at 8 bits.  For apps with more than 256 threads, this will cause ambiguity.

## Performance Impact

It will increase file size by 1 byte/memop = 11%

The locks probably slow it down a bit too.

## Testing Assessment

I created a trace with it and opened it in the tool.  It appears that hdf5 is smart enough to be backwards compatible so that adding the new field doesn't break compatibility with the current viewer.

Does that match your understanding of hdf5?
